### PR TITLE
Add index file that imports bits from all downstream files

### DIFF
--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -59,14 +59,17 @@ impl BindingGenerator for NodeBindingGenerator {
     ) -> Result<()> {
         for uniffi_bindgen::Component { ci, config: _, .. } in components {
             let sys_ts_main_file_name = format!("{}-sys", ci.namespace().to_kebab_case());
+            let node_ts_main_file_name = format!("{}-node", ci.namespace().to_kebab_case());
 
             let Bindings {
                 package_json_contents,
-                sys_template_contents,
+                sys_ts_template_contents,
                 node_ts_file_contents,
+                index_ts_file_contents,
             } = generate_node_bindings(
                 &ci,
                 sys_ts_main_file_name.as_str(),
+                node_ts_main_file_name.as_str(),
                 self.out_dirname_api.clone(),
                 self.out_disable_auto_loading_lib,
                 self.out_import_extension.clone(),
@@ -75,11 +78,14 @@ impl BindingGenerator for NodeBindingGenerator {
             let package_json_path = settings.out_dir.join("package.json");
             write_with_dirs(&package_json_path, package_json_contents)?;
 
-            let node_ts_file_path = settings.out_dir.join(format!("{}-node.ts", ci.namespace().to_kebab_case()));
+            let node_ts_file_path = settings.out_dir.join(format!("{node_ts_main_file_name}.ts"));
             write_with_dirs(&node_ts_file_path, node_ts_file_contents)?;
 
             let sys_template_path = settings.out_dir.join(format!("{sys_ts_main_file_name}.ts"));
-            write_with_dirs(&sys_template_path, sys_template_contents)?;
+            write_with_dirs(&sys_template_path, sys_ts_template_contents)?;
+
+            let index_template_path = settings.out_dir.join("index.ts");
+            write_with_dirs(&index_template_path, index_ts_file_contents)?;
         }
 
         Ok(())

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -1,0 +1,7 @@
+{%- import "macros.ts" as ts -%}
+
+export * from './{%- call ts::import_file_path(node_ts_main_file_name) -%}';
+
+{% if out_disable_auto_loading_lib %}
+export { uniffiLoad, uniffiUnload } from './{%- call ts::import_file_path(sys_ts_main_file_name) -%}';
+{% endif %}

--- a/templates/node.ts
+++ b/templates/node.ts
@@ -256,11 +256,6 @@ import FFI_DYNAMIC_LIB, {
   {%- endfor %}
 } from './{%- call ts::import_file_path(sys_ts_main_file_name) -%}';
 
-{% if out_disable_auto_loading_lib %}
-export { uniffiLoad, uniffiUnload } from './{%- call ts::import_file_path(sys_ts_main_file_name) -%}';
-{% endif %}
-
-
 
 // ==========
 // Record definitions:


### PR DESCRIPTION
This means that the entrypoint that downstream code needs to import from can be a fixed / predictable file and not a file that changes name.

I considered just renaming the `-node.ts` file to `index.ts` but the reason I made this name dynamic was so that I could test multiple different packages where their bindgens are outputting into the same `output/` directory and that is kinda a nice property that I'd like to keep working at least for the time being. But this might be a decision worth revisiting in the future.