### PR TITLE
Add node version flag

### DIFF
--- a/src/bindings/generator.rs
+++ b/src/bindings/generator.rs
@@ -21,11 +21,12 @@ pub struct Bindings {
 #[template(escape = "none", path = "package.json")]
 struct PackageJsonTemplate<'ci> {
     ci: &'ci ComponentInterface,
+    out_node_version: String,
 }
 
 impl<'ci> PackageJsonTemplate<'ci> {
-    pub fn new(ci: &'ci ComponentInterface) -> Self {
-        Self { ci }
+    pub fn new(ci: &'ci ComponentInterface, out_node_version: &str) -> Self {
+        Self { ci, out_node_version: out_node_version.into() }
     }
 }
 
@@ -103,8 +104,9 @@ pub fn generate_node_bindings(
     out_dirname_api: DirnameApi,
     out_disable_auto_loading_lib: bool,
     out_import_extension: ImportExtension,
+    out_node_version: &str,
 ) -> Result<Bindings> {
-    let package_json_contents = PackageJsonTemplate::new(ci).render().context("failed to render package.json template")?;
+    let package_json_contents = PackageJsonTemplate::new(ci, out_node_version).render().context("failed to render package.json template")?;
     let sys_template_contents = SysTemplate::new(ci, out_dirname_api, out_disable_auto_loading_lib).render().context("failed to render sys.ts template")?;
     let node_ts_file_contents = NodeTsTemplate::new(ci, sys_ts_main_file_name, out_import_extension.clone()).render().context("failed to render node.ts template")?;
     let index_ts_file_contents = IndexTsTemplate::new(node_ts_main_file_name, sys_ts_main_file_name, out_import_extension, out_disable_auto_loading_lib).render().context("failed to render index.ts template")?;

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -17,6 +17,7 @@ pub struct NodeBindingGenerator {
     out_dirname_api: utils::DirnameApi,
     out_disable_auto_loading_lib: bool,
     out_import_extension: utils::ImportExtension,
+    out_node_version: String,
 }
 
 impl NodeBindingGenerator {
@@ -24,8 +25,14 @@ impl NodeBindingGenerator {
         out_dirname_api: utils::DirnameApi,
         out_disable_auto_loading_lib: bool,
         out_import_extension: utils::ImportExtension,
+        out_node_version: &str,
     ) -> Self {
-        Self { out_dirname_api, out_disable_auto_loading_lib, out_import_extension }
+        Self {
+            out_dirname_api,
+            out_disable_auto_loading_lib,
+            out_import_extension,
+            out_node_version: out_node_version.into(),
+        }
     }
 }
 
@@ -73,6 +80,7 @@ impl BindingGenerator for NodeBindingGenerator {
                 self.out_dirname_api.clone(),
                 self.out_disable_auto_loading_lib,
                 self.out_import_extension.clone(),
+                self.out_node_version.as_str(),
             )?;
 
             let package_json_path = settings.out_dir.join("package.json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,11 @@ pub struct Args {
     #[arg(long, action, value_enum, default_value_t=OutputImportExtension::default())]
     out_import_extension: OutputImportExtension,
 
+    /// Specifies the version (in semver) of node that the typescript bindings will depend on in
+    /// the built output. By default, this is "^18".
+    #[arg(long, default_value = "^18")]
+    out_node_version: String,
+
     /// Config file override.
     #[arg(short, long)]
     config_override: Option<Utf8PathBuf>,
@@ -95,6 +100,7 @@ pub fn run(args: Args) -> Result<()> {
         args.out_dirname_api.into(),
         args.out_disable_auto_load_lib,
         args.out_import_extension.into(),
+        args.out_node_version.as_str(),
     );
 
     uniffi_bindgen::library_mode::generate_bindings(

--- a/templates/package.json
+++ b/templates/package.json
@@ -1,13 +1,16 @@
 {
   "name": "lib{{ ci.crate_name().to_kebab_case() }}",
   "description": "Uniffi wrapper around the {{ ci.crate_name() }} rust crate.",
+  "engines": {
+    "node": "{{out_node_version}}"
+  },
   "dependencies": {
     "ffi-rs": "^1.3.0",
     "ref-napi": "^3.0.3",
     "uniffi-bindgen-react-native": "^0.29.3-1"
   },
   "devDependencies": {
-    "@types/node": "^24.9.2",
+    "@types/node": "{{out_node_version}}",
     "@types/ref-napi": "^3.0.12"
   }
 }


### PR DESCRIPTION
This allows the caller to dictate the supported node version range.

For now, there's no validation on this, but I could see some validation existing in the future.