### PR TITLE
Add verbose logging flag

### DIFF
--- a/src/bindings/generator.rs
+++ b/src/bindings/generator.rs
@@ -56,18 +56,21 @@ struct NodeTsTemplate<'ci> {
     ci: &'ci ComponentInterface,
     sys_ts_main_file_name: String,
     out_import_extension: ImportExtension,
+    out_verbose_logs: bool,
 }
 
 impl<'ci> NodeTsTemplate<'ci> {
     pub fn new(
         ci: &'ci ComponentInterface,
         sys_ts_main_file_name: &str,
-        out_import_extension: ImportExtension
+        out_import_extension: ImportExtension,
+        out_verbose_logs: bool,
     ) -> Self {
         Self {
             ci,
             sys_ts_main_file_name: sys_ts_main_file_name.to_string(),
             out_import_extension,
+            out_verbose_logs,
         }
     }
 }
@@ -105,10 +108,11 @@ pub fn generate_node_bindings(
     out_disable_auto_loading_lib: bool,
     out_import_extension: ImportExtension,
     out_node_version: &str,
+    out_verbose_logs: bool,
 ) -> Result<Bindings> {
     let package_json_contents = PackageJsonTemplate::new(ci, out_node_version).render().context("failed to render package.json template")?;
     let sys_template_contents = SysTemplate::new(ci, out_dirname_api, out_disable_auto_loading_lib).render().context("failed to render sys.ts template")?;
-    let node_ts_file_contents = NodeTsTemplate::new(ci, sys_ts_main_file_name, out_import_extension.clone()).render().context("failed to render node.ts template")?;
+    let node_ts_file_contents = NodeTsTemplate::new(ci, sys_ts_main_file_name, out_import_extension.clone(), out_verbose_logs).render().context("failed to render node.ts template")?;
     let index_ts_file_contents = IndexTsTemplate::new(node_ts_main_file_name, sys_ts_main_file_name, out_import_extension, out_disable_auto_loading_lib).render().context("failed to render index.ts template")?;
 
     Ok(Bindings {

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -18,6 +18,7 @@ pub struct NodeBindingGenerator {
     out_disable_auto_loading_lib: bool,
     out_import_extension: utils::ImportExtension,
     out_node_version: String,
+    out_verbose_logs: bool,
 }
 
 impl NodeBindingGenerator {
@@ -26,12 +27,14 @@ impl NodeBindingGenerator {
         out_disable_auto_loading_lib: bool,
         out_import_extension: utils::ImportExtension,
         out_node_version: &str,
+        out_verbose_logs: bool,
     ) -> Self {
         Self {
             out_dirname_api,
             out_disable_auto_loading_lib,
             out_import_extension,
             out_node_version: out_node_version.into(),
+            out_verbose_logs,
         }
     }
 }
@@ -81,6 +84,7 @@ impl BindingGenerator for NodeBindingGenerator {
                 self.out_disable_auto_loading_lib,
                 self.out_import_extension.clone(),
                 self.out_node_version.as_str(),
+                self.out_verbose_logs,
             )?;
 
             let package_json_path = settings.out_dir.join("package.json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,11 @@ pub struct Args {
     #[arg(long, default_value = "^18")]
     out_node_version: String,
 
+    /// If passed, adds verbose logging to the bindgen output, which is helpful for debugging
+    /// issues in the bindgne itself.
+    #[arg(long, action)]
+    out_verbose_logs: bool,
+
     /// Config file override.
     #[arg(short, long)]
     config_override: Option<Utf8PathBuf>,
@@ -101,6 +106,7 @@ pub fn run(args: Args) -> Result<()> {
         args.out_disable_auto_load_lib,
         args.out_import_extension.into(),
         args.out_node_version.as_str(),
+        args.out_verbose_logs,
     );
 
     uniffi_bindgen::library_mode::generate_bindings(

--- a/templates/node.ts
+++ b/templates/node.ts
@@ -22,7 +22,7 @@
         return;
       }
 
-      console.log("async cleanup last poll callback pointer");
+      {% if out_verbose_logs -%}console.log("async cleanup last poll callback pointer");{%- endif -%}
       freePointer({
         paramsType: [funcConstructor({
             paramsType: [DataType.U64, /* i8 */ DataType.U8],
@@ -44,7 +44,7 @@
       // doesn't support.
       /*rustCaller:*/ uniffiCaller as unknown as UniffiRustCaller<UniffiRustCallStatus>,
       /*rustFutureFunc:*/ () => {
-        console.log("{{ func_def.ffi_func().name() }} async call starting...");
+        {% if out_verbose_logs -%}console.log("{{ func_def.ffi_func().name() }} async call starting...");{%- endif -%}
         const returnedHandle = FFI_DYNAMIC_LIB.{{ func_def.ffi_func().name() }}([
           {% if let Some(self_type) = func_def.self_type() -%}
             {{ associated_object_name | typescript_ffi_object_factory_name }}.clonePointer(this)
@@ -61,20 +61,20 @@
             callStatus
           {%- endif %}
         ]);
-        console.log("{{ func_def.ffi_func().name() }} returned handle:", returnedHandle);
+        {% if out_verbose_logs -%}console.log("{{ func_def.ffi_func().name() }} returned handle:", returnedHandle);{%- endif -%}
         return returnedHandle;
       },
       /*pollFunc:*/ (handle, callback, callbackData) => {
         cleanupLastPollCallbackPointer();
 
-        console.log("{{ func_def.ffi_func().name() }} async poll:", handle, callback, callbackData);
+        {% if out_verbose_logs -%}console.log("{{ func_def.ffi_func().name() }} async poll:", handle, callback, callbackData);{%- endif -%}
         const wrappedCallback = (callbackData: bigint, pollCodeRaw: number) => {
           // NOTE: ffi-rs doesn't support a DataType.I8 value under the hood, so instead `pollCode`
           // is being returned as a DataType.U8 as it is the same byte size. The below code
           // does the conversion from U8 -> I8.
           const pollCode = ((pollCodeRaw & 0b10000000) > 0 ? -1 : 1) * (pollCodeRaw & 0x01111111);
 
-          console.log('{{ func_def.ffi_func().name() }} async poll callback fired with:', callbackData, pollCode);
+          {% if out_verbose_logs -%}console.log('{{ func_def.ffi_func().name() }} async poll callback fired with:', callbackData, pollCode);{%- endif -%}
           callback(
             BigInt(callbackData), /* FIXME: why must I convert callbackData from number -> bigint here? It looks like even though it is typed as DataType.U64 callbackData is passed as a number? */
             pollCode,
@@ -95,19 +95,18 @@
           unwrapped,
           Number(callbackData) /* FIXME: why must I convert callbackData from bigint -> number here for the ffi call to succeed? */
         ]);
-        console.log('{{ func_def.ffi_func().name() }} async poll done');
-        // setTimeout(() => { console.log('settimeout complete')}, 5000);
+        {% if out_verbose_logs -%}console.log('{{ func_def.ffi_func().name() }} async poll done');{%- endif -%}
       },
       /*cancelFunc:*/ (handle) => {
-        console.log('{{ func_def.ffi_func().name() }} async cancel:');
+        {% if out_verbose_logs -%}console.log('{{ func_def.ffi_func().name() }} async cancel:');{%- endif -%}
         return FFI_DYNAMIC_LIB.{{ func_def.ffi_rust_future_cancel(ci) }}([handle])
       },
       /*completeFunc:*/ (handle, callStatus) => {
-        console.log('{{ func_def.ffi_func().name() }} async complete:');
+        {% if out_verbose_logs -%}console.log('{{ func_def.ffi_func().name() }} async complete:');{%- endif -%}
         return FFI_DYNAMIC_LIB.{{ func_def.ffi_rust_future_complete(ci) }}([handle, callStatus])
       },
       /*freeFunc:*/ (handle) => {
-        console.log('{{ func_def.ffi_func().name() }} async free:');
+        {% if out_verbose_logs -%}console.log('{{ func_def.ffi_func().name() }} async free:');{%- endif -%}
         cleanupLastPollCallbackPointer();
         return FFI_DYNAMIC_LIB.{{ func_def.ffi_rust_future_free(ci) }}([handle])
       },
@@ -139,7 +138,7 @@
           let {{ arg.name() | typescript_argument_var_name }} = {{ arg.name() | typescript_var_name | typescript_ffi_converter_lower_with(arg.as_type().borrow()) }};
         {% endfor -%}
 
-        console.log("{{ func_def.ffi_func().name() }} call starting...");
+        {% if out_verbose_logs -%}console.log("{{ func_def.ffi_func().name() }} call starting...");{%- endif -%}
         const returnValue = FFI_DYNAMIC_LIB.{{ func_def.ffi_func().name() }}([
           {% if let Some(self_type) = func_def.self_type() -%}
             {{ associated_object_name | typescript_ffi_object_factory_name }}.clonePointer(this)
@@ -156,7 +155,7 @@
             callStatus
           {%- endif %}
         ]);
-        console.log("{{ func_def.ffi_func().name() }} return value:", returnValue{%- if func_def.ffi_func().has_rust_call_status_arg() -%}, 'Call status:', callStatus{%- endif -%});
+        {% if out_verbose_logs -%}console.log("{{ func_def.ffi_func().name() }} return value:", returnValue{%- if func_def.ffi_func().has_rust_call_status_arg() -%}, 'Call status:', callStatus{%- endif -%});{%- endif -%}
 
         return returnValue;
       },


### PR DESCRIPTION
Right now the bindgen generates verbose logs for all calls, resulting in a lot of log spam. I considered removing them outright, but the bindgen still is fairly early and they have been pretty helpful for debugging edge cases. So instead, add a verbose logging flag to turn them on or off.

In the future once the bindgen is more stable, I could see these logs / this flag maybe getting removed.