### PR TITLE
A collection of small bugfixes / hacks

### DIFF
--- a/templates/node.ts
+++ b/templates/node.ts
@@ -274,7 +274,13 @@ export type {{ record_def.name() | typescript_class_name }} = {
   {%- for field_def in record_def.fields() -%}
     {% call ts::docstring(field_def, 0) %}
     {%- let type_ = field_def.as_type() %}
-    {{field_def.name() | typescript_var_name}}: {{field_def | typescript_type_name}};
+
+    {%- match field_def.as_type() -%}
+    {%- when Type::Optional { inner_type } -%}
+      {{field_def.name() | typescript_var_name}}?: {{inner_type | typescript_type_name}};
+    {%- else -%}
+      {{field_def.name() | typescript_var_name}}: {{field_def | typescript_type_name}};
+    {%- endmatch -%}
   {%- endfor %}
 }
 


### PR DESCRIPTION
- Add whitespace after verbose `console.log`s to make the output a little easier to read
- Dig a bit more into what is going on with some of the async function type checking issues:
  - Add some type assrtions to make number <-> bigint conversion not throw type errors. See the code for more info, I think there might be a bug in ffi-rs where it uses `number` for `u64`s (which makes no sense because a `u64` can't be 100% faithfully represented in a `number`)
  - Add another type assertion to work around an issue which presented itself because of the already existing `UniffiRustCaller<UniffiRustCallStatus>` type assertion. Again I left a bit of a lengthy comment in the code with more context... just generally though, this is starting to make me thing either we need to propose some upstream changes to the ubrn helper utility (removing the generic bound on `UniffiRustCaller` so `UniffiRustCaller<JsExternal>` would be valid), or need to move away from the ubrn helper library for async function calling.
- Fix an accidental `0x` (which should have been `0b`)
- Render out optional Record fields like `{field?: type}` rather than `{field: type | undefined}` so that they can be omitted