### PR TITLE
Add ability to override library that bindgen loads in at runtime via the environment

### DIFF
--- a/templates/sys.ts
+++ b/templates/sys.ts
@@ -55,16 +55,25 @@ function _uniffiLoad() {
   {%- endmatch %}
 
   // Get the path to the lib to load
+
+  // 1. Use the library passed in the environment with the highest precidence
+  let libraryPath = process.env[`${library.toUpperCase()}_PATH`];
+
+  // 2. Or, fallback to the at build time defined mechanism
   {% match out_lib_path -%}
     {%- when LibPath::Omitted -%}
-      const libraryPath = join(libraryDirectory, `${library}.${ext}`);
+      if (!libraryPath) {
+        libraryPath = join(libraryDirectory, `${library}.${ext}`);
+      }
 
     {% when LibPath::Literal(literal) %}
-      {%- if literal.is_absolute() -%}
-        const libraryPath = "{{ literal }}";
-      {%- else -%}
-        const libraryPath = join(libraryDirectory, "{{ literal }}");
-      {%- endif -%}
+      if (!libraryPath) {
+        {%- if literal.is_absolute() -%}
+          libraryPath = "{{ literal }}";
+        {%- else -%}
+          libraryPath = join(libraryDirectory, "{{ literal }}");
+        {%- endif -%}
+      }
 
     {% when LibPath::Modules(mods) %}
       let libPathModule;
@@ -105,7 +114,9 @@ function _uniffiLoad() {
         throw new Error(messageFragments.join('\n'));
       }
 
-      const libraryPath = libPathModule.default().path;
+      if (!libraryPath) {
+        libraryPath = libPathModule.default().path;
+      }
 
   {% endmatch %}
 


### PR DESCRIPTION
The thinking with this is it provides a way that developers or users can potentially use a newly built native core for testing / debugging without having to fully rebuild the node end of the bindgen.

I have seen this pattern in other bindgen type tools so I think it probably is a good one, but I'm definitely open to thoughts here on if this is a good idea or should be the concern of user code higher up the stack.

(Note - I tested this in a livekit downstream implementer of the bindgen with success, so I am confident this works in its current state.)