### PR TITLE
Free RustCallStatus pointer after every Rust call

### DIFF
--- a/templates/sys.ts
+++ b/templates/sys.ts
@@ -195,15 +195,23 @@ class UniffiFfiRsRustCaller {
     _checkUniffiLoaded();
 
     const $callStatus = this.createCallStatus();
-    let returnedVal = caller(unwrapPointer($callStatus)[0]);
+    try {
+      let returnedVal = caller(unwrapPointer($callStatus)[0]);
 
-    const [callStatus] = restorePointer({
-      retType: [DataType_UniffiRustCallStatus],
-      paramsValue: $callStatus,
-    });
-    uniffiCheckCallStatus(callStatus, liftString, liftError);
+      const [callStatus] = restorePointer({
+        retType: [DataType_UniffiRustCallStatus],
+        paramsValue: $callStatus,
+      });
+      uniffiCheckCallStatus(callStatus, liftString, liftError);
 
-    return returnedVal;
+      return returnedVal;
+    } finally {
+      freePointer({
+        paramsType: [DataType_UniffiRustCallStatus],
+        paramsValue: $callStatus,
+        pointerType: PointerType.RsPointer,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Every synchronous call into Rust through `makeRustCall` leaks the call-status struct that gets passed in. Wrap the call site in `try`/`finally` and reclaim the pointer with `freePointer`.

## Why this is a leak

`createCallStatus` calls `ffi-rs`'s `createPointer({ paramsType: [DataType_UniffiRustCallStatus], ... })`. `DataType_UniffiRustCallStatus` does not set `ffiTypeTag: DataType.StackStruct` (only the inner `error_buf` field does), so ffi-rs takes the heap-allocation branch in `get_value_pointer`:

```rust
RsArgsValue::Object(val) => {
  if is_stack_struct {
    generate_c_struct(...)
  } else {
    Box::into_raw(Box::new(generate_c_struct(...))) as *mut c_void
  }
}
```

That produces two heap allocations: the struct itself (via `generate_c_struct`) and a wrapper `Box<*mut c_void>`. Neither is owned by JS. From the ffi-rs README: *"JsExternal objects do NOT automatically free memory upon garbage collection. Use `freePointer` to free the pointer when it is no longer in use."* `restorePointer` is read-only, and `unwrapPointer` only produces a new external around the inner pointer — neither reclaims the original allocation.

Net effect: every sync FFI call leaks roughly the size of `UniffiRustCallStatus` plus a pointer-sized wrapper. Method calls leak it twice (once for `clonePointer`, once for the actual call). Constructors, `uniffiDestroy`, and the FinalizationRegistry-driven free path each leak it once. For long-running or high-throughput consumers this is unbounded growth.

## How the fix works

`makeRustCall` now wraps the call site in `try`/`finally` and calls `freePointer` on `$callStatus` in the `finally` block, using the same `DataType_UniffiRustCallStatus` paramsType and `PointerType.RsPointer` so ffi-rs takes the matching free path (`free_rs_pointer_memory` Object branch: dealloc the struct memory and reclaim the wrapper). The `finally` ensures the pointer is freed whether the Rust call returned normally, the call status indicated an error and `uniffiCheckCallStatus` threw, or any other exception propagated through the body.