### PR TITLE
Free wrapper Box created by wrapPointer in toUint8Array

### DIFF
--- a/templates/sys.ts
+++ b/templates/sys.ts
@@ -356,12 +356,22 @@ export class UniffiRustBufferValue {
       throw new Error(`Error converting rust buffer to uint8array - rust buffer length is ${this.struct.len}, which cannot be represented as a Number safely.`)
     }
 
-    const [contents] = restorePointer({
-      retType: [arrayConstructor({ type: DataType.U8Array, length: Number(this.struct.len) })],
-      paramsValue: wrapPointer([this.struct.data]),
-    });
+    const length = Number(this.struct.len);
+    const wrapped = wrapPointer([this.struct.data]);
+    try {
+      const [contents] = restorePointer({
+        retType: [arrayConstructor({ type: DataType.U8Array, length })],
+        paramsValue: wrapped,
+      });
 
-    return new Uint8Array(contents);
+      return new Uint8Array(contents);
+    } finally {
+      freePointer({
+        paramsType: [arrayConstructor({ type: DataType.U8Array, length })],
+        paramsValue: wrapped,
+        pointerType: PointerType.RsPointer,
+      });
+    }
   }
 
   consumeIntoUint8Array() {


### PR DESCRIPTION
## Summary

`UniffiRustBufferValue.toUint8Array` allocates a wrapper `Box` via `wrapPointer` and never reclaims it. Free it in a `finally` block.

## Why this is a leak

`toUint8Array` does:

```ts
const [contents] = restorePointer({
  retType: [arrayConstructor({ type: DataType.U8Array, length: ... })],
  paramsValue: wrapPointer([this.struct.data]),
});
```

`ffi-rs`'s `wrap_pointer` heap-allocates a fresh `Box` around the inner pointer:

```rust
env.create_external(
  Box::into_raw(Box::new(ptr)),
  Some(std::mem::size_of::<*mut c_void>() as i64),
)
```

Per ffi-rs's documented contract — *"JsExternal objects do NOT automatically free memory upon garbage collection. Use `freePointer` to free the pointer when it is no longer in use."* — that wrapper `Box` is only reclaimed when `freePointer` is called on the resulting external. `restorePointer` is documented (and implemented) as a read-only conversion. Nothing here calls `freePointer`, so the wrapper `Box` is leaked on every invocation.

`toUint8Array` is on the hot path for error handling: `uniffiCheckCallStatus` calls `consumeIntoUint8Array` (which calls `toUint8Array`) for every `CALL_ERROR` and `CALL_UNEXPECTED_ERROR` response with a non-null `error_buf`. It's also reachable directly from user code lifting buffer-shaped return values. Each call leaks one pointer-sized `Box`.

## How the fix works

Capture the `wrapPointer` result in a local (`wrapped`) so it can be referenced in both the `try` and `finally` halves, and lift `Number(this.struct.len)` into `length` so the `arrayConstructor` shape is byte-identical between the `restorePointer` and the matching `freePointer`. After `restorePointer` reads the bytes out, `freePointer({ paramsType: [arrayConstructor({ type: DataType.U8Array, length })], paramsValue: wrapped, pointerType: PointerType.RsPointer })` runs unconditionally.

ffi-rs's free path for a `U8Array` (`free_rs_pointer_memory` → `RefDataType::U8Array`) is `Box::from_raw(ptr as *mut *mut u8)`, which only reclaims the wrapper Box. The underlying buffer the wrapper points at is owned by the Rust side and is released separately through `rustbuffer_free` when `destroy()` runs — so it stays intact.